### PR TITLE
chore(utils-locations): exclude JavaScript files from ts-jest transformation

### DIFF
--- a/libs/shared/utils/locations/jest.config.ts
+++ b/libs/shared/utils/locations/jest.config.ts
@@ -3,7 +3,7 @@ export default {
   preset: '../../../../jest.preset.js',
   testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
     // Exclude .js files from transformation
     '^.+\\.js$': 'babel-jest',
   },


### PR DESCRIPTION


Modified the Jest configuration to exclude JavaScript files from being transformed by ts-jest, preventing the 'allowJs' warning.