### PR TITLE
fix(ericbuettner-com/profile-snapshot): adjust position of social media icons for small and medium screen sizes

### DIFF
--- a/libs/ericbuettner-com/profile-snapshot/src/lib/ericbuettner-com/profile-information.tsx
+++ b/libs/ericbuettner-com/profile-snapshot/src/lib/ericbuettner-com/profile-information.tsx
@@ -25,8 +25,8 @@ export function ProfileInformation(props: ProfileInformationProps) {
   const formattedLocation = formatLocationToString(structuredLocation);
 
   return (
-    <div className="profile-information text-center sm:grow lg:grow-0">
-      <h1 className="text-2xl py-2">
+    <>
+      <h1 className="profile-information text-2xl py-2">
         {props.first_name} {props.last_name}
       </h1>
       <p className="profile-information-job text-gray-700 py-2">
@@ -34,6 +34,6 @@ export function ProfileInformation(props: ProfileInformationProps) {
         {props.latest_job_company ? ' at ' + props.latest_job_company : ''}
       </p>
       <p className="text-sm text-gray-500 py-2">{formattedLocation}</p>
-    </div>
+    </>
   );
 }

--- a/libs/ericbuettner-com/profile-snapshot/src/lib/ericbuettner-com/profile-snapshot.tsx
+++ b/libs/ericbuettner-com/profile-snapshot/src/lib/ericbuettner-com/profile-snapshot.tsx
@@ -26,16 +26,18 @@ export function ProfileSnapshot(props: ProfileSnapshotProps) {
         src="/assets/profile/eric-buettner.jpeg"
         alt={`Portrait of ${props.first_name} ${props.last_name}`}
       />
-      <ProfileInformation
-        first_name={props.first_name}
-        last_name={props.last_name}
-        latest_job_company={props.latest_job_company}
-        latest_job_position={props.latest_job_position}
-        location_city={props.location_city}
-        location_state={props.location_state}
-        location_country={props.location_country}
-      />
-      <SocialMediaLinks socialMediaLinks={socialLinks} />
+      <div className="text-center sm:grow">
+        <ProfileInformation
+          first_name={props.first_name}
+          last_name={props.last_name}
+          latest_job_company={props.latest_job_company}
+          latest_job_position={props.latest_job_position}
+          location_city={props.location_city}
+          location_state={props.location_state}
+          location_country={props.location_country}
+        />
+        <SocialMediaLinks socialMediaLinks={socialLinks} />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
This commit fixes the layout issue where social media icons were misaligned on screen widths ranging from 640px to 1024px. Now, the icons are correctly positioned below the job title, ensuring better visual consistency and user experience across medium-sized devices.

closes #278