### PR TITLE
chore: update `commitlint` configuration and Husky scripts

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no-install commitlint --edit $1
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run format:check
+npm run affected:lint
+npm run affected:test

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/package.json
+++ b/package.json
@@ -3,8 +3,15 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
+    "prepare": "husky install",
     "start": "nx serve",
     "build": "nx build",
+    "format": "nx format:write",
+    "format:check": "nx format:check",
+    "format:write": "nx format:write",
+    "affected:build": "npx nx affected -t build",
+    "affected:lint": "npx nx affected -t lint",
+    "affected:test": "npx nx affected -t test",
     "test": "nx test"
   },
   "private": true,


### PR DESCRIPTION
This commit updates several aspects of the project:

- `commitlint.config.js` is now configured to extend '@commitlint/config-conventional'.
- In `package.json`, the 'prepare', 'format', 'format:check', 'format:write', 'affected:build', 'affected:lint' and 'affected:test' scripts have been defined.
- In `.husky/commit-msg`, the command 'npx --no-install commitlint --edit $1' has been changed to 'npx --no -- commitlint --edit "$1"'.
- In `.husky/pre-commit`, the commands 'npm run affected:lint' and 'npm run affected:test' have been added for linting and testing before committing.

These changes enhance commit message linting and pre-commit checks.