### PR TITLE
build: specify node and npm engine versions in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "tuffz-nx-workspace",
   "version": "0.0.0",
   "license": "MIT",
+  "engines": {
+    "node": "20",
+    "npm": "9 || 10"
+  },
   "scripts": {
     "prepare": "husky install",
     "start": "nx serve",


### PR DESCRIPTION
Added 'engines' field to package.json to explicitly specify the required Node.js and npm versions for the project. This update sets the Node.js version requirement to 20 and allows for npm versions 9 or 10. This change ensures compatibility and consistent behavior across different development environments.