### PR TITLE
refactor(social-media-icons)!: change size prop to accept numbers

### DIFF
--- a/libs/ericbuettner-com/profile-snapshot/src/lib/ericbuettner-com/social-media-links.tsx
+++ b/libs/ericbuettner-com/profile-snapshot/src/lib/ericbuettner-com/social-media-links.tsx
@@ -14,7 +14,7 @@ export function SocialMediaLinks({ socialMediaLinks }: SocialMediaLinksProps) {
       <p className="flex flex-wrap justify-center">
         {socialMediaLinks.map((link, index) => (
           <span key={index} className="px-1 mx-1 text-sm">
-            <UiSocialMediaIcons size="1.5rem" url={link.url} />
+            <UiSocialMediaIcons size={24} url={link.url} />
           </span>
         ))}
       </p>

--- a/libs/shared/ui/social-media-icons/src/lib/ui-social-media-icons.tsx
+++ b/libs/shared/ui/social-media-icons/src/lib/ui-social-media-icons.tsx
@@ -8,12 +8,12 @@ import { UiSocialMediaIconTwitter } from './icons/twitter';
 import { UiSocialMediaIconX } from './icons/x';
 
 export interface UiSocialMediaIconsProps {
-  size: string;
+  size: number;
   url: string;
 }
 
 export interface UiSocialMediaIconProps {
-  size: string;
+  size: number;
 }
 
 interface PlatformMapping {


### PR DESCRIPTION
BREAKING CHANGE: This commit modifies the `size` prop in the `UiSocialMediaIconsProps` and `UiSocialMediaIconProps` interfaces to accept numbers instead of strings, which constitutes a breaking change. The `size` prop now expects numeric values to improve type safety and maintain consistency across the component.