### PR TITLE
ci(renovate): add minimum release age of 3 days to npm packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,11 @@
   "rebaseWhen": "behind-base-branch",
   "separateMajorMinor": true,
   "separateMultipleMajor": true,
-  "separateMinorPatch": true
+  "separateMinorPatch": true,
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    }
+  ]
 }


### PR DESCRIPTION
- Added a package rule for `npm` with a minimum release age of 3 days.