### PR TITLE
chore: refine changelog generation configuration

### DIFF
--- a/apps/coding-booth-com-e2e/CHANGELOG.md
+++ b/apps/coding-booth-com-e2e/CHANGELOG.md
@@ -46,7 +46,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.1.22](https://github.com/tuffz/tuffz-nx-workspace/compare/coding-booth-com-e2e-0.1.21...coding-booth-com-e2e-0.1.22) (2024-01-11)
 
-
 ### ♻️ Code Refactoring
 
 * refactor: update conventional-changelog generator configuration ([#307](https://github.com/tuffz/tuffz-nx-workspace/issues/307)) ([fb18b84](https://github.com/tuffz/tuffz-nx-workspace/commit/fb18b84855e1b2fa06a2579b0eae23f88fa186a9))

--- a/apps/coding-booth-com-e2e/project.json
+++ b/apps/coding-booth-com-e2e/project.json
@@ -35,11 +35,7 @@
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }

--- a/apps/coding-booth-com/CHANGELOG.md
+++ b/apps/coding-booth-com/CHANGELOG.md
@@ -46,7 +46,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.1.22](https://github.com/tuffz/tuffz-nx-workspace/compare/coding-booth-com-1.1.21...coding-booth-com-1.1.22) (2024-01-11)
 
-
 ### ♻️ Code Refactoring
 
 * refactor: update conventional-changelog generator configuration ([#307](https://github.com/tuffz/tuffz-nx-workspace/issues/307)) ([fb18b84](https://github.com/tuffz/tuffz-nx-workspace/commit/fb18b84855e1b2fa06a2579b0eae23f88fa186a9))
@@ -114,7 +113,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.0.6](https://github.com/tuffz/tuffz-nx-workspace/compare/coding-booth-com-1.0.5...coding-booth-com-1.0.6) (2023-12-17)
 
-
 ### Bug Fixes
 
 * **coding-booth-com:** refine layout and styling ([#252](https://github.com/tuffz/tuffz-nx-workspace/issues/252)) ([7152b5e](https://github.com/tuffz/tuffz-nx-workspace/commit/7152b5e6a14d0982e744b9098bc9bf3d20b3d91b))
@@ -148,7 +146,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 * **coding-booth-com:** introduce Plausible.io analytics ([dab408e](https://github.com/tuffz/tuffz-nx-workspace/commit/dab408e19ef6bbc1930147260bba6cb6c7f427fb))
 * **coding-booth-com:** redesign main application layout and content ([ef03a67](https://github.com/tuffz/tuffz-nx-workspace/commit/ef03a67e512f81aa80b280c7e2e1e2d5f1855ed2))
 * **ui-footer:** introduce dynamic utm_source query in the footer link ([68ce45c](https://github.com/tuffz/tuffz-nx-workspace/commit/68ce45c447a3ffb446aa7e36e3bb53d8dfa22265))
-
 
 ### Bug Fixes
 

--- a/apps/coding-booth-com/project.json
+++ b/apps/coding-booth-com/project.json
@@ -97,11 +97,7 @@
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }

--- a/apps/ericbuettner-com-e2e/CHANGELOG.md
+++ b/apps/ericbuettner-com-e2e/CHANGELOG.md
@@ -28,7 +28,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [2.0.1](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com-e2e-2.0.0...ericbuettner-com-e2e-2.0.1) (2024-01-21)
 
-
 ### 📝 Documentation
 
 * **ericbuettner-com:** bump major version and add breaking changes description to changelog ([#334](https://github.com/tuffz/tuffz-nx-workspace/issues/334)) ([d78f89d](https://github.com/tuffz/tuffz-nx-workspace/commit/d78f89d1dba5100494b79a361008cff8be27abef))

--- a/apps/ericbuettner-com-e2e/project.json
+++ b/apps/ericbuettner-com-e2e/project.json
@@ -30,46 +30,12 @@
         "commitMessageFormat": "chore({projectName}): 🚀 release version ${version} [skip ci]",
         "preset": {
           "types": [
-            {
-              "type": "feat",
-              "section": "✨ Features"
-            },
-            {
-              "type": "fix",
-              "section": "🐛 Bug Fixes"
-            },
-            {
-              "type": "chore",
-              "section": "⚙️ Chores"
-            },
-            {
-              "type": "build",
-              "section": "🛠️ Build System"
-            },
-            {
-              "type": "ci",
-              "section": "🤖 Continuous Integration"
-            },
-            {
-              "type": "docs",
-              "section": "📝 Documentation"
-            },
-            {
-              "type": "style",
-              "section": "🚨 Styles"
-            },
-            {
-              "type": "refactor",
-              "section": "♻️ Code Refactoring"
-            },
-            {
-              "type": "perf",
-              "section": "⚡️ Performance Improvements"
-            },
-            {
-              "type": "test",
-              "section": "✅ Tests"
-            }
+            { "type": "feat", "section": "✨ Features" },
+            { "type": "fix", "section": "🐛 Bug Fixes" },
+            { "type": "docs", "section": "📝 Documentation" },
+            { "type": "refactor", "section": "♻️ Code Refactoring" },
+            { "type": "perf", "section": "⚡️ Performance Improvements" },
+            { "type": "test", "section": "✅ Tests" }
           ]
         },
         "skipCommitTypes": [

--- a/apps/ericbuettner-com/CHANGELOG.md
+++ b/apps/ericbuettner-com/CHANGELOG.md
@@ -8,11 +8,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [3.0.11](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com-3.0.10...ericbuettner-com-3.0.11) (2024-02-01)
 
-
-### ⚙️ Chores
-
-* **deps:** update nextjs monorepo to v14 (major) ([#335](https://github.com/tuffz/tuffz-nx-workspace/issues/335)) ([acf461f](https://github.com/tuffz/tuffz-nx-workspace/commit/acf461f8a9cf137c2eabd2cb0ac1b3062ab46f65))
-
 ## [3.0.10](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com-3.0.9...ericbuettner-com-3.0.10) (2024-02-01)
 
 ## [3.0.9](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com-3.0.8...ericbuettner-com-3.0.9) (2024-02-01)
@@ -23,11 +18,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [3.0.6](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com-3.0.5...ericbuettner-com-3.0.6) (2024-02-01)
 
-
-### ⚙️ Chores
-
-* **ericbuettner-com:** update ignore patterns in .eslintrc.json ([#357](https://github.com/tuffz/tuffz-nx-workspace/issues/357)) ([75d3236](https://github.com/tuffz/tuffz-nx-workspace/commit/75d323606c665688cd17f720dc2457db695e9777))
-
 ## [3.0.5](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com-3.0.4...ericbuettner-com-3.0.5) (2024-02-01)
 
 ## [3.0.4](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com-3.0.3...ericbuettner-com-3.0.4) (2024-01-25)
@@ -37,7 +27,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [3.0.2](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com-3.0.1...ericbuettner-com-3.0.2) (2024-01-21)
 
 ## [3.0.1](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com-3.0.0...ericbuettner-com-3.0.1) (2024-01-21)
-
 
 ### 📝 Documentation
 

--- a/apps/ericbuettner-com/project.json
+++ b/apps/ericbuettner-com/project.json
@@ -61,46 +61,12 @@
         "commitMessageFormat": "chore({projectName}): 🚀 release version ${version}",
         "preset": {
           "types": [
-            {
-              "type": "feat",
-              "section": "✨ Features"
-            },
-            {
-              "type": "fix",
-              "section": "🐛 Bug Fixes"
-            },
-            {
-              "type": "chore",
-              "section": "⚙️ Chores"
-            },
-            {
-              "type": "build",
-              "section": "🛠️ Build System"
-            },
-            {
-              "type": "ci",
-              "section": "🤖 Continuous Integration"
-            },
-            {
-              "type": "docs",
-              "section": "📝 Documentation"
-            },
-            {
-              "type": "style",
-              "section": "🚨 Styles"
-            },
-            {
-              "type": "refactor",
-              "section": "♻️ Code Refactoring"
-            },
-            {
-              "type": "perf",
-              "section": "⚡️ Performance Improvements"
-            },
-            {
-              "type": "test",
-              "section": "✅ Tests"
-            }
+            { "type": "feat", "section": "✨ Features" },
+            { "type": "fix", "section": "🐛 Bug Fixes" },
+            { "type": "docs", "section": "📝 Documentation" },
+            { "type": "refactor", "section": "♻️ Code Refactoring" },
+            { "type": "perf", "section": "⚡️ Performance Improvements" },
+            { "type": "test", "section": "✅ Tests" }
           ]
         },
         "skipCommitTypes": [

--- a/apps/tuffz-com-e2e/CHANGELOG.md
+++ b/apps/tuffz-com-e2e/CHANGELOG.md
@@ -46,7 +46,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.0.165](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-com-e2e-0.0.164...tuffz-com-e2e-0.0.165) (2024-01-11)
 
-
 ### ♻️ Code Refactoring
 
 * refactor: update conventional-changelog generator configuration ([#307](https://github.com/tuffz/tuffz-nx-workspace/issues/307)) ([fb18b84](https://github.com/tuffz/tuffz-nx-workspace/commit/fb18b84855e1b2fa06a2579b0eae23f88fa186a9))
@@ -116,6 +115,7 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Dependency Updates
 
 * `tuffz-com` updated to version `1.1.0`
+
 ## [0.0.137](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-com-e2e-0.0.136...tuffz-com-e2e-0.0.137) (2023-12-14)
 
 ## [0.0.136](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-com-e2e-0.0.135...tuffz-com-e2e-0.0.136) (2023-12-13)
@@ -183,6 +183,7 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Dependency Updates
 
 * `tuffz-com` updated to version `1.0.0`
+
 ## [0.0.105](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-com-e2e-0.0.104...tuffz-com-e2e-0.0.105) (2023-11-30)
 
 ## [0.0.104](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-com-e2e-0.0.103...tuffz-com-e2e-0.0.104) (2023-11-27)
@@ -320,6 +321,7 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Dependency Updates
 
 * `tuffz-com` updated to version `0.1.0`
+
 ## [0.0.38](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-com-e2e-0.0.37...tuffz-com-e2e-0.0.38) (2023-11-13)
 
 ## [0.0.37](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-com-e2e-0.0.36...tuffz-com-e2e-0.0.37) (2023-11-13)
@@ -397,4 +399,5 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Dependency Updates
 
 * `tuffz-com` updated to version `0.0.2`
+
 ## 0.0.1 (2023-11-13)

--- a/apps/tuffz-com-e2e/project.json
+++ b/apps/tuffz-com-e2e/project.json
@@ -35,11 +35,7 @@
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }

--- a/apps/tuffz-com/project.json
+++ b/apps/tuffz-com/project.json
@@ -91,11 +91,7 @@
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }

--- a/libs/coding-booth-com/under-construction/CHANGELOG.md
+++ b/libs/coding-booth-com/under-construction/CHANGELOG.md
@@ -32,7 +32,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.1.29](https://github.com/tuffz/tuffz-nx-workspace/compare/coding-booth-com/under-construction-0.1.28...coding-booth-com/under-construction-0.1.29) (2024-01-21)
 
-
 ### 🚨 Styles
 
 * introduce eslint rule for tailwindcss ([#327](https://github.com/tuffz/tuffz-nx-workspace/issues/327)) ([7ba6a88](https://github.com/tuffz/tuffz-nx-workspace/commit/7ba6a880f7cb58073201f8f6947456abc2fcbc05))
@@ -50,7 +49,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [0.1.23](https://github.com/tuffz/tuffz-nx-workspace/compare/coding-booth-com/under-construction-0.1.22...coding-booth-com/under-construction-0.1.23) (2024-01-11)
 
 ## [0.1.22](https://github.com/tuffz/tuffz-nx-workspace/compare/coding-booth-com/under-construction-0.1.21...coding-booth-com/under-construction-0.1.22) (2024-01-11)
-
 
 ### ♻️ Code Refactoring
 

--- a/libs/coding-booth-com/under-construction/project.json
+++ b/libs/coding-booth-com/under-construction/project.json
@@ -25,11 +25,7 @@
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }

--- a/libs/ericbuettner-com/career-timeline/CHANGELOG.md
+++ b/libs/ericbuettner-com/career-timeline/CHANGELOG.md
@@ -20,11 +20,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [2.0.9](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/career-timeline-2.0.8...ericbuettner-com/career-timeline-2.0.9) (2024-02-01)
 
-
-### ⚙️ Chores
-
-* **deps:** update nrwl monorepo to v17.3.1 (minor) ([#355](https://github.com/tuffz/tuffz-nx-workspace/issues/355)) ([f65b4ac](https://github.com/tuffz/tuffz-nx-workspace/commit/f65b4ac6b01a216227d181dc9a290df4de6995ad))
-
 ## [2.0.8](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/career-timeline-2.0.7...ericbuettner-com/career-timeline-2.0.8) (2024-01-25)
 
 ## [2.0.7](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/career-timeline-2.0.6...ericbuettner-com/career-timeline-2.0.7) (2024-01-21)
@@ -37,7 +32,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [2.0.3](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/career-timeline-2.0.2...ericbuettner-com/career-timeline-2.0.3) (2024-01-21)
 
-
 ### 🚨 Styles
 
 * introduce eslint rule for tailwindcss ([#327](https://github.com/tuffz/tuffz-nx-workspace/issues/327)) ([7ba6a88](https://github.com/tuffz/tuffz-nx-workspace/commit/7ba6a880f7cb58073201f8f6947456abc2fcbc05))
@@ -48,7 +42,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [2.0.0](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/career-timeline-1.0.10...ericbuettner-com/career-timeline-2.0.0) (2024-01-17)
 
-
 ### ⚠ BREAKING CHANGES
 
 * **career-timeline:** This removal should not impact the functionality of the CareerTimeline component
@@ -57,7 +50,6 @@ itself, and it is considered a refactor rather than a breaking change.
 ### 🐛 Bug Fixes
 
 * **career-timeline:** resolve Safari "Invalid Date" issue ([baa40cd](https://github.com/tuffz/tuffz-nx-workspace/commit/baa40cd5aee82a584930eb49e8fbcab65ee940f8))
-
 
 ### ♻️ Code Refactoring
 
@@ -79,13 +71,11 @@ itself, and it is considered a refactor rather than a breaking change.
 
 ## [1.0.7](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/career-timeline-1.0.6...ericbuettner-com/career-timeline-1.0.7) (2024-01-11)
 
-
 ### ♻️ Code Refactoring
 
 * refactor: update conventional-changelog generator configuration ([#307](https://github.com/tuffz/tuffz-nx-workspace/issues/307)) ([fb18b84](https://github.com/tuffz/tuffz-nx-workspace/commit/fb18b84855e1b2fa06a2579b0eae23f88fa186a9))
 
 ## [1.0.6](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/career-timeline-1.0.5...ericbuettner-com/career-timeline-1.0.6) (2024-01-10)
-
 
 ### ✅ Tests
 
@@ -110,7 +100,6 @@ itself, and it is considered a refactor rather than a breaking change.
 ## [1.0.1](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/career-timeline-1.0.0...ericbuettner-com/career-timeline-1.0.1) (2024-01-06)
 
 ## 1.0.0 (2024-01-06)
-
 
 ### ⚠ BREAKING CHANGES
 

--- a/libs/ericbuettner-com/career-timeline/project.json
+++ b/libs/ericbuettner-com/career-timeline/project.json
@@ -25,46 +25,12 @@
         "commitMessageFormat": "chore({projectName}): 🚀 release version ${version} [skip ci]",
         "preset": {
           "types": [
-            {
-              "type": "feat",
-              "section": "✨ Features"
-            },
-            {
-              "type": "fix",
-              "section": "🐛 Bug Fixes"
-            },
-            {
-              "type": "chore",
-              "section": "⚙️ Chores"
-            },
-            {
-              "type": "build",
-              "section": "🛠️ Build System"
-            },
-            {
-              "type": "ci",
-              "section": "🤖 Continuous Integration"
-            },
-            {
-              "type": "docs",
-              "section": "📝 Documentation"
-            },
-            {
-              "type": "style",
-              "section": "🚨 Styles"
-            },
-            {
-              "type": "refactor",
-              "section": "♻️ Code Refactoring"
-            },
-            {
-              "type": "perf",
-              "section": "⚡️ Performance Improvements"
-            },
-            {
-              "type": "test",
-              "section": "✅ Tests"
-            }
+            { "type": "feat", "section": "✨ Features" },
+            { "type": "fix", "section": "🐛 Bug Fixes" },
+            { "type": "docs", "section": "📝 Documentation" },
+            { "type": "refactor", "section": "♻️ Code Refactoring" },
+            { "type": "perf", "section": "⚡️ Performance Improvements" },
+            { "type": "test", "section": "✅ Tests" }
           ]
         },
         "skipCommitTypes": [

--- a/libs/ericbuettner-com/profile-snapshot/CHANGELOG.md
+++ b/libs/ericbuettner-com/profile-snapshot/CHANGELOG.md
@@ -32,7 +32,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [3.1.12](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-3.1.11...ericbuettner-com/profile-snapshot-3.1.12) (2024-01-21)
 
-
 ### 🚨 Styles
 
 * introduce eslint rule for tailwindcss ([#327](https://github.com/tuffz/tuffz-nx-workspace/issues/327)) ([7ba6a88](https://github.com/tuffz/tuffz-nx-workspace/commit/7ba6a880f7cb58073201f8f6947456abc2fcbc05))
@@ -48,6 +47,7 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Dependency Updates
 
 * `utils-locations` updated to version `3.0.0`
+
 ## [3.1.7](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-3.1.6...ericbuettner-com/profile-snapshot-3.1.7) (2024-01-12)
 
 ### Dependency Updates
@@ -63,7 +63,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [3.1.5](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-3.1.4...ericbuettner-com/profile-snapshot-3.1.5) (2024-01-11)
 
 ## [3.1.4](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-3.1.3...ericbuettner-com/profile-snapshot-3.1.4) (2024-01-11)
-
 
 ### ♻️ Code Refactoring
 
@@ -87,7 +86,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [3.1.0](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-3.0.31...ericbuettner-com/profile-snapshot-3.1.0) (2024-01-06)
 
-
 ### Features
 
 * **eric-buettner/profile-snapshot:** adjust `font-size` and `font-weight` for name display ([23886dd](https://github.com/tuffz/tuffz-nx-workspace/commit/23886dd3c2724a074e797ce335150d0ad97839e2))
@@ -103,7 +101,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [3.0.27](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-3.0.26...ericbuettner-com/profile-snapshot-3.0.27) (2024-01-03)
 
 ## [3.0.26](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-3.0.25...ericbuettner-com/profile-snapshot-3.0.26) (2024-01-03)
-
 
 ### Bug Fixes
 
@@ -170,9 +167,9 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 * **utils-locations:** Rename library from `utils-format-locations` to `utils-locations`
 
 Split the location functionality into distinct files
-- `structure-location.ts` contains the interfaces and the `structureLocation` function
+* `structure-location.ts` contains the interfaces and the `structureLocation` function
   for converting `Location` to `StructuredLocation`
-- `format-location.ts` holds the `formatLocationToString` function for formatting
+* `format-location.ts` holds the `formatLocationToString` function for formatting
   `StructuredLocation`into a string
 
 ### Features
@@ -196,6 +193,7 @@ Split the location functionality into distinct files
 ### Dependency Updates
 
 * `utils-format-location` updated to version `1.0.0`
+
 ## [2.1.9](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-2.1.8...ericbuettner-com/profile-snapshot-2.1.9) (2023-12-08)
 
 ## [2.1.8](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-2.1.7...ericbuettner-com/profile-snapshot-2.1.8) (2023-12-08)
@@ -236,7 +234,6 @@ Split the location functionality into distinct files
 ## [2.0.2](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-2.0.1...ericbuettner-com/profile-snapshot-2.0.2) (2023-12-02)
 
 ## [2.0.1](https://github.com/tuffz/tuffz-nx-workspace/compare/ericbuettner-com/profile-snapshot-2.0.0...ericbuettner-com/profile-snapshot-2.0.1) (2023-12-02)
-
 
 ### Bug Fixes
 
@@ -281,6 +278,7 @@ Split the location functionality into distinct files
 ### Dependency Updates
 
 * `ui-social-media-icons` updated to version `1.2.0`
+
 ## [0.2.0](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-info-professional-biography-short-0.1.42...tuffz-info-professional-biography-short-0.2.0) (2023-11-29)
 
 ### Dependency Updates
@@ -316,6 +314,7 @@ Split the location functionality into distinct files
 ### Dependency Updates
 
 * `shared-ui-image-embed` updated to version `0.1.0`
+
 ## [0.1.35](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-info-professional-biography-short-0.1.34...tuffz-info-professional-biography-short-0.1.35) (2023-11-22)
 
 ## [0.1.34](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-info-professional-biography-short-0.1.33...tuffz-info-professional-biography-short-0.1.34) (2023-11-21)
@@ -387,7 +386,6 @@ Split the location functionality into distinct files
 ## [0.1.1](https://github.com/tuffz/tuffz-nx-workspace/compare/tuffz-info-professional-biography-short-0.1.0...tuffz-info-professional-biography-short-0.1.1) (2023-11-13)
 
 ## 0.1.0 (2023-11-13)
-
 
 ### Features
 

--- a/libs/ericbuettner-com/profile-snapshot/project.json
+++ b/libs/ericbuettner-com/profile-snapshot/project.json
@@ -22,14 +22,11 @@
         "baseBranch": "main",
         "commitMessageFormat": "chore({projectName}): 🚀 release version ${version} [skip ci]",
         "preset": {
+          "name": "conventionalcommits",
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }

--- a/libs/shared/ui/anchor/CHANGELOG.md
+++ b/libs/shared/ui/anchor/CHANGELOG.md
@@ -46,7 +46,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [3.0.57](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-anchor-3.0.56...ui-anchor-3.0.57) (2024-01-11)
 
-
 ### ♻️ Code Refactoring
 
 * refactor: update conventional-changelog generator configuration ([#307](https://github.com/tuffz/tuffz-nx-workspace/issues/307)) ([fb18b84](https://github.com/tuffz/tuffz-nx-workspace/commit/fb18b84855e1b2fa06a2579b0eae23f88fa186a9))
@@ -54,7 +53,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [3.0.56](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-anchor-3.0.55...ui-anchor-3.0.56) (2024-01-10)
 
 ## [3.0.55](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-anchor-3.0.54...ui-anchor-3.0.55) (2024-01-10)
-
 
 ### 🧹 Code Refactoring
 
@@ -170,7 +168,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [3.0.0](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-anchor-2.0.0...ui-anchor-3.0.0) (2023-12-01)
 
-
 ### ⚠ BREAKING CHANGES
 
 * remove the obsolete `shared` prefix in `shared-ui-anchor`, `shared-ui-footer` and `shared-ui-image-embed` library and class names
@@ -181,7 +178,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [2.0.0](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-anchor-1.2.38...shared-ui-anchor-2.0.0) (2023-11-30)
 
-
 ### ⚠ BREAKING CHANGES
 
 * **shared-ui-anchor:** SharedUiAnchorProps interface's `title` property is mandatory instead of optional.
@@ -189,7 +185,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Features
 
 * **shared-ui-anchor:** allow ReactNode as content property value ([e4bca18](https://github.com/tuffz/tuffz-nx-workspace/commit/e4bca186347d2989fa558d0e6123528fc0862ec6))
-
 
 ### Code Refactoring
 
@@ -273,13 +268,11 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.2.0](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-anchor-1.1.0...shared-ui-anchor-1.2.0) (2023-11-13)
 
-
 ### Features
 
 * **shared-ui-anchor:** add `rel` attribute logic for use case target="_blank" ([3737a2a](https://github.com/tuffz/tuffz-nx-workspace/commit/3737a2a8fb71a05c23016a9b441b9b9b837c79e3))
 
 ## [1.1.0](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-anchor-1.0.0...shared-ui-anchor-1.1.0) (2023-11-13)
-
 
 ### Features
 
@@ -287,11 +280,9 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.0.0](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-anchor-0.1.1...shared-ui-anchor-1.0.0) (2023-11-13)
 
-
 ### ⚠ BREAKING CHANGES
 
 * **shared-ui-anchor:** rename property of the link content/text from `body` to `content`
-
 
 ### Code Refactoring
 
@@ -300,7 +291,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [0.1.1](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-anchor-0.1.0...shared-ui-anchor-0.1.1) (2023-11-13)
 
 ## 0.1.0 (2023-11-13)
-
 
 ### Features
 

--- a/libs/shared/ui/anchor/project.json
+++ b/libs/shared/ui/anchor/project.json
@@ -22,14 +22,11 @@
         "baseBranch": "main",
         "commitMessageFormat": "chore({projectName}): 🚀 release version ${version} [skip ci]",
         "preset": {
+          "name": "conventionalcommits",
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }

--- a/libs/shared/ui/footer/CHANGELOG.md
+++ b/libs/shared/ui/footer/CHANGELOG.md
@@ -32,7 +32,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [3.0.34](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-footer-3.0.33...ui-footer-3.0.34) (2024-01-21)
 
-
 ### 🚨 Styles
 
 * introduce eslint rule for tailwindcss ([#327](https://github.com/tuffz/tuffz-nx-workspace/issues/327)) ([7ba6a88](https://github.com/tuffz/tuffz-nx-workspace/commit/7ba6a880f7cb58073201f8f6947456abc2fcbc05))
@@ -50,7 +49,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [3.0.28](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-footer-3.0.27...ui-footer-3.0.28) (2024-01-11)
 
 ## [3.0.27](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-footer-3.0.26...ui-footer-3.0.27) (2024-01-11)
-
 
 ### ♻️ Code Refactoring
 
@@ -118,7 +116,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [3.0.0](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-footer-2.1.18...ui-footer-3.0.0) (2023-12-15)
 
-
 ### ⚠ BREAKING CHANGES
 
 * **ui-footer:** `UiFooterProps` interface now requires a `website` property.
@@ -165,7 +162,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [2.1.1](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-footer-2.1.0...ui-footer-2.1.1) (2023-12-05)
 
 ## [2.1.0](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-footer-2.0.11...ui-footer-2.1.0) (2023-12-05)
-
 
 ### Features
 
@@ -307,13 +303,11 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [0.2.8](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-footer-0.2.7...shared-ui-footer-0.2.8) (2023-11-13)
 
-
 ### Bug Fixes
 
 * **shared-ui-footer:** correct mispelled content ([6ed5d0e](https://github.com/tuffz/tuffz-nx-workspace/commit/6ed5d0ebcfa523be03fa595eefe4136b8ee86fa2))
 
 ## [0.2.7](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-footer-0.2.6...shared-ui-footer-0.2.7) (2023-11-13)
-
 
 ### Bug Fixes
 
@@ -324,16 +318,19 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Dependency Updates
 
 * `shared-ui-anchor` updated to version `1.2.0`
+
 ## [0.2.5](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-footer-0.2.4...shared-ui-footer-0.2.5) (2023-11-13)
 
 ### Dependency Updates
 
 * `shared-ui-anchor` updated to version `1.1.0`
+
 ## [0.2.4](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-footer-0.2.3...shared-ui-footer-0.2.4) (2023-11-13)
 
 ### Dependency Updates
 
 * `shared-ui-anchor` updated to version `1.0.0`
+
 ## [0.2.3](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-footer-0.2.2...shared-ui-footer-0.2.3) (2023-11-13)
 
 ## [0.2.2](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-footer-0.2.1...shared-ui-footer-0.2.2) (2023-11-13)
@@ -343,8 +340,8 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ### Dependency Updates
 
 * `shared-ui-anchor` updated to version `0.1.0`
-## [0.2.0](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-footer-0.1.16...shared-ui-footer-0.2.0) (2023-11-13)
 
+## [0.2.0](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-footer-0.1.16...shared-ui-footer-0.2.0) (2023-11-13)
 
 ### Features
 
@@ -383,7 +380,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [0.1.1](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-footer-0.1.0...shared-ui-footer-0.1.1) (2023-11-13)
 
 ## 0.1.0 (2023-11-13)
-
 
 ### Features
 

--- a/libs/shared/ui/footer/project.json
+++ b/libs/shared/ui/footer/project.json
@@ -25,11 +25,7 @@
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }

--- a/libs/shared/ui/image-embed/CHANGELOG.md
+++ b/libs/shared/ui/image-embed/CHANGELOG.md
@@ -46,7 +46,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [1.0.57](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-image-embed-1.0.56...ui-image-embed-1.0.57) (2024-01-11)
 
-
 ### ♻️ Code Refactoring
 
 * refactor: update conventional-changelog generator configuration ([#307](https://github.com/tuffz/tuffz-nx-workspace/issues/307)) ([fb18b84](https://github.com/tuffz/tuffz-nx-workspace/commit/fb18b84855e1b2fa06a2579b0eae23f88fa186a9))
@@ -54,7 +53,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [1.0.56](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-image-embed-1.0.55...ui-image-embed-1.0.56) (2024-01-10)
 
 ## [1.0.55](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-image-embed-1.0.54...ui-image-embed-1.0.55) (2024-01-10)
-
 
 ### 🧹 Code Refactoring
 
@@ -170,7 +168,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## 1.0.0 (2023-12-01)
 
-
 ### ⚠ BREAKING CHANGES
 
 * remove the obsolete `shared` prefix in `shared-ui-anchor`, `shared-ui-footer` and `shared-ui-image-embed` library and class names
@@ -179,7 +176,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 * **shared-ui-image-embed:** add new library ([9d8c445](https://github.com/tuffz/tuffz-nx-workspace/commit/9d8c445f29aa5ec0f97537ba4df57e3eb411a4e3))
 * **shared-ui-image-embed:** implement fallback to utilize 'alt' when 'title' is not provided ([158b222](https://github.com/tuffz/tuffz-nx-workspace/commit/158b222948f72e573d4fd5592d1d6f44a79ba543))
-
 
 ### Code Refactoring
 
@@ -196,7 +192,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [0.1.1](https://github.com/tuffz/tuffz-nx-workspace/compare/shared-ui-image-embed-0.1.0...shared-ui-image-embed-0.1.1) (2023-11-22)
 
 ## 0.1.0 (2023-11-22)
-
 
 ### Features
 

--- a/libs/shared/ui/image-embed/project.json
+++ b/libs/shared/ui/image-embed/project.json
@@ -32,11 +32,7 @@
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }

--- a/libs/shared/ui/social-media-icons/CHANGELOG.md
+++ b/libs/shared/ui/social-media-icons/CHANGELOG.md
@@ -32,7 +32,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [4.0.5](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-social-media-icons-4.0.4...ui-social-media-icons-4.0.5) (2024-01-21)
 
-
 ### 🚨 Styles
 
 * introduce eslint rule for tailwindcss ([#327](https://github.com/tuffz/tuffz-nx-workspace/issues/327)) ([7ba6a88](https://github.com/tuffz/tuffz-nx-workspace/commit/7ba6a880f7cb58073201f8f6947456abc2fcbc05))
@@ -46,7 +45,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 ## [4.0.1](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-social-media-icons-4.0.0...ui-social-media-icons-4.0.1) (2024-01-13)
 
 ## [4.0.0](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-social-media-icons-3.1.52...ui-social-media-icons-4.0.0) (2024-01-12)
-
 
 ### ⚠ BREAKING CHANGES
 
@@ -64,7 +62,6 @@ consistency across the component.
 ## [3.1.51](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-social-media-icons-3.1.50...ui-social-media-icons-3.1.51) (2024-01-11)
 
 ## [3.1.50](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-social-media-icons-3.1.49...ui-social-media-icons-3.1.50) (2024-01-11)
-
 
 ### ♻️ Code Refactoring
 
@@ -178,7 +175,6 @@ consistency across the component.
 
 ## [3.1.0](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-social-media-icons-3.0.6...ui-social-media-icons-3.1.0) (2023-12-03)
 
-
 ### Features
 
 * **ui-social-media-icons:** introduce LinkedIn icon ([b74bb35](https://github.com/tuffz/tuffz-nx-workspace/commit/b74bb358aeba0ddd7b2eb87d998e4fa3e3a3220b))
@@ -211,7 +207,6 @@ consistency across the component.
 
 * **ui-social-media-icons:** add twitter and x.com ([35b4894](https://github.com/tuffz/tuffz-nx-workspace/commit/35b4894130afa2e70c5db8bc09ddb994165f1818))
 
-
 ### Code Refactoring
 
 * **ui-social-media-icons:** introduce `size` property for flexible icon sizing ([2f042c4](https://github.com/tuffz/tuffz-nx-workspace/commit/2f042c4a04cf37a6fddfd8ee2642dde4f4590704))
@@ -243,7 +238,6 @@ consistency across the component.
 
 ## [1.1.0](https://github.com/tuffz/tuffz-nx-workspace/compare/ui-social-media-icons-1.0.1...ui-social-media-icons-1.1.0) (2023-11-29)
 
-
 ### Features
 
 * **shared-social-media-icons:** add GitLab icon ([bede60f](https://github.com/tuffz/tuffz-nx-workspace/commit/bede60f879127822f53e41ffc7104dea39551f32))
@@ -252,7 +246,6 @@ consistency across the component.
 
 ## 1.0.0 (2023-11-27)
 
-
 ### ⚠ BREAKING CHANGES
 
 * **shared-ui-social-media-icons:** pump version to 1.0.0
@@ -260,7 +253,6 @@ consistency across the component.
 ### Features
 
 * **shared-ui-social-media-icons:** add new library ([#145](https://github.com/tuffz/tuffz-nx-workspace/issues/145)) ([2173442](https://github.com/tuffz/tuffz-nx-workspace/commit/2173442e25fbdf20729cf646a19f6499462f9052))
-
 
 ### Bug Fixes
 

--- a/libs/shared/ui/social-media-icons/project.json
+++ b/libs/shared/ui/social-media-icons/project.json
@@ -25,11 +25,7 @@
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }

--- a/libs/shared/utils/locations/CHANGELOG.md
+++ b/libs/shared/utils/locations/CHANGELOG.md
@@ -40,7 +40,6 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ## [3.0.0](https://github.com/tuffz/tuffz-nx-workspace/compare/utils-locations-2.0.36...utils-locations-3.0.0) (2024-01-13)
 
-
 ### ⚠ BREAKING CHANGES
 
 * **utils-locations:** The behavior of the `structureLocation` function has changed, which may impact code
@@ -57,7 +56,6 @@ function handles the `state` property when it's the same as `city`.
 
 ## [2.0.34](https://github.com/tuffz/tuffz-nx-workspace/compare/utils-locations-2.0.33...utils-locations-2.0.34) (2024-01-11)
 
-
 ### ♻️ Code Refactoring
 
 * refactor: update conventional-changelog generator configuration ([#307](https://github.com/tuffz/tuffz-nx-workspace/issues/307)) ([fb18b84](https://github.com/tuffz/tuffz-nx-workspace/commit/fb18b84855e1b2fa06a2579b0eae23f88fa186a9))
@@ -65,7 +63,6 @@ function handles the `state` property when it's the same as `city`.
 ## [2.0.33](https://github.com/tuffz/tuffz-nx-workspace/compare/utils-locations-2.0.32...utils-locations-2.0.33) (2024-01-10)
 
 ## [2.0.32](https://github.com/tuffz/tuffz-nx-workspace/compare/utils-locations-2.0.31...utils-locations-2.0.32) (2024-01-10)
-
 
 ### 🧹 Code Refactoring
 
@@ -135,15 +132,14 @@ function handles the `state` property when it's the same as `city`.
 
 ## [2.0.0](https://github.com/tuffz/tuffz-nx-workspace/compare/utils-locations-1.0.6...utils-locations-2.0.0) (2023-12-10)
 
-
 ### ⚠ BREAKING CHANGES
 
 * **utils-locations:** Rename library from `utils-format-locations` to `utils-locations`
 
 Split the location functionality into distinct files
-- `structure-location.ts` contains the interfaces and the `structureLocation` function
+* `structure-location.ts` contains the interfaces and the `structureLocation` function
   for converting `Location` to `StructuredLocation`
-- `format-location.ts` holds the `formatLocationToString` function for formatting
+* `format-location.ts` holds the `formatLocationToString` function for formatting
   `StructuredLocation`into a string
 
 ### Features
@@ -163,7 +159,6 @@ Split the location functionality into distinct files
 ## [1.0.1](https://github.com/tuffz/tuffz-nx-workspace/compare/utils-format-location-1.0.0...utils-format-location-1.0.1) (2023-12-10)
 
 ## 1.0.0 (2023-12-10)
-
 
 ### ⚠ BREAKING CHANGES
 

--- a/libs/shared/utils/locations/project.json
+++ b/libs/shared/utils/locations/project.json
@@ -35,11 +35,7 @@
           "types": [
             { "type": "feat", "section": "✨ Features" },
             { "type": "fix", "section": "🐛 Bug Fixes" },
-            { "type": "chore", "section": "⚙️ Chores" },
-            { "type": "build", "section": "🛠️ Build System" },
-            { "type": "ci", "section": "🤖 Continuous Integration" },
             { "type": "docs", "section": "📝 Documentation" },
-            { "type": "style", "section": "🚨 Styles" },
             { "type": "refactor", "section": "♻️ Code Refactoring" },
             { "type": "perf", "section": "⚡️ Performance Improvements" },
             { "type": "test", "section": "✅ Tests" }


### PR DESCRIPTION
Removed unnecessary changelog headlines for `chore`, `build`, `ci`, and `style`.