### PR TITLE
feat(renovate): update Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,43 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    ":assignAndReview(tuffz)",
+    ":automergePatch",
+    ":automergePr",
+    ":automergeStableNonMajor",
+    ":automergeRequireAllStatusChecks",
+    ":disableRateLimiting",
+    "labels(renovate, dependencies)",
+    ":pinDependencies",
+    ":pinDevDependencies",
+    ":rebaseStalePrs",
+    ":semanticPrefixFixDepsChoreOthers",
+    ":separateMultipleMajorReleases",
+    ":separateMultipleMinorReleases",
+    ":separatePatchReleases"
+  ],
   "baseBranches": ["main"],
-  "assignees": ["tuffz"],
-  "labels": ["renovate", "dependencies"],
-  "rebaseWhen": "behind-base-branch",
-  "separateMajorMinor": true,
-  "separateMultipleMajor": true,
-  "separateMinorPatch": true,
   "packageRules": [
+    { "matchDatasources": ["npm"], "minimumReleaseAge": "3 days" },
     {
-      "matchDatasources": ["npm"],
-      "minimumReleaseAge": "3 days"
+      "description": "Run migrations on Nx updates",
+      "extends": ["monorepo:nrwl"],
+      "groupName": "Nx monorepo",
+      "matchUpdateTypes": ["digest", "patch", "minor", "major"],
+      "postUpgradeTasks": {
+        "commands": [
+          "npm cache clean --force",
+          "npm ci",
+          "echo '{\"migrations\": []}' > migrations.json",
+          "npx nx migrate @nx/workspace --from='@nx/workspace@{{{currentVersion}}}'",
+          "npx nx migrate --run-migrations=migrations.json",
+          "npm install",
+          "npm run format:write"
+        ],
+        "fileFilters": ["**/**", "**/.*", ".*/**", ".*/**/.*", ".*"]
+      },
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
This commit updates the Renovate configuration to include several new settings and features for better dependency management and automation:

- Extends Renovate's recommended configuration with additional presets and settings to enhance automation and management of pull requests.
- Adds specific configuration for assigning and reviewing pull requests to a designated user (`tuffz`).
- Enables automatic merging of patch updates.
- Enables automatic merging of pull requests.
- Enables automatic merging of stable non-major updates.
- Requires all status checks to pass before automatically merging.
- Disables rate limiting for faster updates.
- Adds labels to pull requests for easier categorization (`renovate`, `dependencies`).
- Pins dependencies to specific versions to ensure consistency.
- Pins devDependencies to specific versions.
- Rebases stale pull requests automatically.
- Fixes dependency updates with semantic prefixes (`fix`, `deps`, `chore`, `other`).
- Separates multiple major releases.
- Separates multiple minor releases.
- Separates patch releases.
- Sets base branches to `main`.
- Sets a minimum release age of 3 days for updates from npm.
- Defines a package rule for running migrations on Nx updates within a monorepo setup.
- Configures post-upgrade tasks to ensure proper migration and formatting steps are executed.
- Disables automatic merging for the Nx monorepo package rule to allow manual verification.

These changes enhance the Renovate configuration for better management and automation of dependency updates and migrations within the project.