### PR TITLE
ci(renovate): update Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
     ":automergeStableNonMajor",
     ":automergeRequireAllStatusChecks",
     ":disableRateLimiting",
-    ":doNotPinPackage(@tuffz/utils-locations)",
     ":labels(renovate, dependencies)",
     ":pinDependencies",
     ":pinDevDependencies",


### PR DESCRIPTION
This commit adjusts the Renovate configuration file (`renovate.json`) to remove the pinning of the `@tuffz/utils-locations` package.
Previously, the `:doNotPinPackage(@tuffz/utils-locations)` directive prevented Renovate from automatically updating the version of this package. Removing this directive allows Renovate to update `@tuffz/utils-locations` along with other dependencies, ensuring that the project stays up-to-date with the latest versions of all packages.

ref #471