### PR TITLE
ci(renovate): use the ":assignee(tuffz)" directive instead of ":assignAndReview(tuffz)"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":assignAndReview(tuffz)",
+    ":assignee(tuffz)",
     ":automergePatch",
     ":automergePr",
     ":automergeStableNonMajor",


### PR DESCRIPTION
This commit modifies the Renovate configuration file (`renovate.json`) to use the ":assignee(tuffz)" directive instead of ":assignAndReview(tuffz)".

Previously, the ":assignAndReview(tuffz)" directive was being used to assign and request review from the user "tuffz" for pull requests generated by Renovate. This directive has been replaced with ":assignee(tuffz)" to only assign pull requests to the user without requesting review.