### PR TITLE
ci(renovate): update Renovate package rule for Nx updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,22 +29,10 @@
       "automerge": false
     },
     {
-      "description": "Run migrations on Nx updates",
+      "description": "Prevent automerge on Nx updates",
       "extends": ["monorepo:nrwl"],
       "groupName": "Nx monorepo",
       "matchUpdateTypes": ["digest", "patch", "minor", "major"],
-      "postUpgradeTasks": {
-        "commands": [
-          "npm cache clean --force",
-          "npm ci",
-          "echo '{\"migrations\": []}' > migrations.json",
-          "npx nx migrate @nx/workspace --from='@nx/workspace@{{{currentVersion}}}'",
-          "npx nx migrate --run-migrations=migrations.json",
-          "npm install",
-          "npm run format:write"
-        ],
-        "fileFilters": ["**/**", "**/.*", ".*/**", ".*/**/.*", ".*"]
-      },
       "automerge": false
     }
   ]


### PR DESCRIPTION
This commit modifies the Renovate package rule related to Nx updates in the `renovate.json` configuration file. Previously, the rule included a post-upgrade task intended for running migrations on Nx updates. However, this task was found to be buggy or not feasible for Renovate. Consequently, the post-upgrade task has been removed from the rule.

Additionally, the automerge property is retained and set to false to prevent automerging for Nx updates. This ensures that changes related to Nx updates will not be automatically merged.

ref #475