### PR TITLE
chore: update Jest preset configuration

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 npm run format:check
-npm run affected:lint
-npm run affected:test
+npm run affected:lint --output-style=static
+npm run affected:test --output-style=static

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -3,5 +3,15 @@ const nxPreset = require('@nx/jest/preset').default;
 const path = require('path');
 module.exports = {
   ...nxPreset,
+  collectCoverage: true,
+  coverageReporters: ['lcov', 'clover', 'text', 'cobertura'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: -10,
+    },
+  },
   setupFilesAfterEnv: [path.resolve(__dirname, './setup-testing-library.js')],
 };

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -5,13 +5,5 @@ module.exports = {
   ...nxPreset,
   collectCoverage: true,
   coverageReporters: ['lcov', 'clover', 'text', 'cobertura'],
-  coverageThreshold: {
-    global: {
-      branches: 80,
-      functions: 80,
-      lines: 80,
-      statements: -10,
-    },
-  },
   setupFilesAfterEnv: [path.resolve(__dirname, './setup-testing-library.js')],
 };


### PR DESCRIPTION
This commit updates the Jest preset configuration in jest.preset.js file.

Changes include:
- Enabling coverage collection with collectCoverage: true.
- Specifying coverage reporters as `['lcov', 'clover', 'text', 'cobertura']`.

These changes aim to improve code coverage reporting and ensure better test coverage for the project.