### PR TITLE
ci(core): update skipCommitTypes configuration for SemVer

### DIFF
--- a/apps/coding-booth-com-e2e/project.json
+++ b/apps/coding-booth-com-e2e/project.json
@@ -41,15 +41,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/apps/coding-booth-com/project.json
+++ b/apps/coding-booth-com/project.json
@@ -103,15 +103,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/apps/ericbuettner-com-e2e/project.json
+++ b/apps/ericbuettner-com-e2e/project.json
@@ -38,15 +38,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/apps/ericbuettner-com/project.json
+++ b/apps/ericbuettner-com/project.json
@@ -69,15 +69,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/apps/tuffz-com-e2e/project.json
+++ b/apps/tuffz-com-e2e/project.json
@@ -41,15 +41,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/apps/tuffz-com/project.json
+++ b/apps/tuffz-com/project.json
@@ -97,15 +97,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/libs/coding-booth-com/under-construction/project.json
+++ b/libs/coding-booth-com/under-construction/project.json
@@ -31,15 +31,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/libs/ericbuettner-com/career-timeline/project.json
+++ b/libs/ericbuettner-com/career-timeline/project.json
@@ -33,15 +33,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/libs/ericbuettner-com/profile-snapshot/project.json
+++ b/libs/ericbuettner-com/profile-snapshot/project.json
@@ -32,15 +32,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/libs/shared/ui-anchor/project.json
+++ b/libs/shared/ui-anchor/project.json
@@ -50,15 +50,7 @@
             }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/libs/shared/ui-footer/project.json
+++ b/libs/shared/ui-footer/project.json
@@ -49,15 +49,7 @@
             }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/libs/shared/ui-image-embed/project.json
+++ b/libs/shared/ui-image-embed/project.json
@@ -56,15 +56,7 @@
             }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/libs/shared/ui/social-media-icons/project.json
+++ b/libs/shared/ui/social-media-icons/project.json
@@ -31,15 +31,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }

--- a/libs/shared/utils/locations/project.json
+++ b/libs/shared/utils/locations/project.json
@@ -41,15 +41,7 @@
             { "type": "test", "section": "✅ Tests" }
           ]
         },
-        "skipCommitTypes": [
-          "build",
-          "chore",
-          "ci",
-          "docs",
-          "refactor",
-          "style",
-          "test"
-        ]
+        "skipCommitTypes": ["build", "chore", "ci", "docs", "style", "test"]
       }
     }
   }


### PR DESCRIPTION
This commit updates the skipCommitTypes configuration in `project.json` files to specify an array of commit types to be ignored when calculating the next version bump. The changes ensure consistency by removing unnecessary commit types such as "refactor" and "ci" from the skip list.

By aligning the skipCommitTypes configuration, we maintain a standardized approach to determining version bumps across different parts of the project, enhancing clarity and maintainability.