### PR TITLE
chore(core): update commitlint configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,40 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'scope-enum': [
+      2,
+      'always',
+      [
+        'core',
+        'coding-booth-com',
+        'ericbuettner-com',
+        'tuffz-com',
+        'coding-booth-com-feature-under-construction',
+        'ericbuettner-com-feature-career-timeline',
+        'ericbuettner-com-feature-profile-snapshot',
+        'shared-ui-anchor',
+        'shared-ui-footer',
+        'shared-ui-image-embed',
+        'shared-ui-social-media-icons',
+        'shared-utils-location-formatting',
+      ],
+    ],
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+        'release',
+      ],
+    ],
+  },
+};


### PR DESCRIPTION
This commit updates the commitlint configuration in commitlint.config.js to enforce stricter rules for scope and type validation. The scope-enum rule now includes an extended list of scopes to ensure consistency across different parts of the project, such as 'core', 'coding-booth-com', 'ericbuettner-com', and others. Similarly, the type-enum rule now includes additional types like 'release' to better categorize commit messages.

By enhancing the commitlint configuration, we improve the quality and consistency of commit messages , making it easier to understand and manage project changes.