### PR TITLE
chore(core): remove Nx defaultProject settings

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -95,6 +95,5 @@
         "linter": "eslint"
       }
     }
-  },
-  "defaultProject": "ericbuettner-com"
+  }
 }


### PR DESCRIPTION
This commit removes the defaultProject setting from the nx.json file. The defaultProject setting was previously set to "ericbuettner-com", but it is no longer needed as the project structure has evolved, and there is no longer a single default project.

Removing this setting ensures that there are no unnecessary configurations in the nx.json file and aligns with the current project structure.