### PR TITLE
docs(core): document step to get latest tag for versioning in GitHub release action

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -10,6 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
+    # Get the latest tag for versioning
     - run: git describe --tags $(git rev-list --tags --max-count=1)
       shell: bash
 


### PR DESCRIPTION
This commit adds a comment to the release action workflow that fetch the latest tag for versioning purposes.

- In the `.github/release/action.yml` file, a new comment is added for the command `git describe --tags $(git rev-list --tags --max-count=1)`, which returns the latest tag