### PR TITLE
build(core): adjust semantic commit type to 'fix' for monorepo:nextjs preset (Renovate)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,13 @@
       "groupName": "Nx monorepo",
       "matchUpdateTypes": ["digest", "patch", "minor", "major"],
       "automerge": false
+    },
+    {
+      "description": "Adjust semantic commit type to 'fix' when updating dependencies in the 'monorepo:nextjs' preset.",
+      "extends": ["monorepo:nextjs"],
+      "groupName": "",
+      "matchDepTypes": ["dependencies", "require"],
+      "semanticCommitType": "fix"
     }
   ]
 }


### PR DESCRIPTION
Adjusted the semantic commit type 'fix' specifically for the 'monorepo:nextjs' preset when updating dependencies. This change ensures that Renovate-generated commit messages follow the correct convention when updating dependencies that are not devDependencies.