### PR TITLE
feat(character-counter): remove unnecessary classes in IntroSection component

### DIFF
--- a/libs/coding-booth-com/feature-character-counter/src/lib/__snapshots__/intro-section.spec.tsx.snap
+++ b/libs/coding-booth-com/feature-character-counter/src/lib/__snapshots__/intro-section.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`IntroSection matches the snapshot 1`] = `
       Introducing
        
       <strong
-        class="text-xl font-bold tracking-tight md:-mb-4 md:text-2xl lg:text-3xl"
+        class="text-xl font-bold tracking-tight md:-mb-4"
       >
         CharacterCounter
       </strong>

--- a/libs/coding-booth-com/feature-character-counter/src/lib/intro-section.tsx
+++ b/libs/coding-booth-com/feature-character-counter/src/lib/intro-section.tsx
@@ -10,7 +10,7 @@ export function IntroSection() {
       </h1>
       <p className="text-lg leading-relaxed opacity-80 dark:text-white">
         Introducing{' '}
-        <strong className="text-xl font-bold tracking-tight md:-mb-4 md:text-2xl lg:text-3xl">
+        <strong className="text-xl font-bold tracking-tight md:-mb-4">
           CharacterCounter
         </strong>{' '}
         - your{' '}

--- a/libs/coding-booth-com/page/home/src/lib/__snapshots__/coding-booth-com-page-home.spec.tsx.snap
+++ b/libs/coding-booth-com/page/home/src/lib/__snapshots__/coding-booth-com-page-home.spec.tsx.snap
@@ -26,7 +26,7 @@ exports[`CodingBoothComPageHome matches the snapshot 1`] = `
         Introducing
          
         <strong
-          class="text-xl font-bold tracking-tight md:-mb-4 md:text-2xl lg:text-3xl"
+          class="text-xl font-bold tracking-tight md:-mb-4"
         >
           CharacterCounter
         </strong>


### PR DESCRIPTION


Removed the unnecessary 'md:text-2xl lg:text-3xl' classes from the <strong> element in the IntroSection component.